### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/context-logger/pom.xml
+++ b/context-logger/pom.xml
@@ -41,7 +41,7 @@
   </modules>
 
   <properties>
-    <commons.collections.version>3.2.1</commons.collections.version>
+    <commons.collections.version>3.2.2</commons.collections.version>
     <jackson.version>1.9.0</jackson.version>
   </properties>
 </project>

--- a/piraso-bridge/server/pom.xml
+++ b/piraso-bridge/server/pom.xml
@@ -18,7 +18,7 @@
     <spring.version>3.1.0.RELEASE</spring.version>
     <commons-io.version>2.2</commons-io.version>
     <commons-lang.version>2.6</commons-lang.version>
-    <commons-collections.version>3.2.1</commons-collections.version>
+    <commons-collections.version>3.2.2</commons-collections.version>
     <slf4j-log4j12.version>1.5.8</slf4j-log4j12.version>
     <mockito-all.version>1.9.0</mockito-all.version>
     <log4j.version>1.2.14</log4j.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
